### PR TITLE
Add separator to node path items in search results

### DIFF
--- a/Resources/Private/Templates/SearchResult/DocumentSearchResult.html
+++ b/Resources/Private/Templates/SearchResult/DocumentSearchResult.html
@@ -11,7 +11,7 @@
 	<div class="breadcrumb">
 		<span>Path:</span>
 		<f:for each="{parents}" as="parent">
-			<neos:link.node node="{parent}" />
+			<neos:link.node node="{parent}" /> /
 		</f:for>
 		<neos:link.node node="{node}" />
 	</div>


### PR DESCRIPTION
Just a small change in DocumentSearchResult template: separator "/" added to node path elements.